### PR TITLE
add checks for DATA_ADMIN_ and DATA_USER_ missing attributes and tests issue #50

### DIFF
--- a/slapd-cli
+++ b/slapd-cli
@@ -213,109 +213,6 @@ syncrepl_get_value() {
 	fi
 }
 
-#====================================================================
-# Load specific parameters
-#====================================================================
-if [ -f ${CLI_CONF_FILE} ]
-then
-	. ${CLI_CONF_FILE}
-	message "info" "[INFO] Using ${CLI_CONF_FILE} for configuration"
-else
-	message "info" "[INFO] Using built-in configuration - this may cause some problems"
-fi
-
-# Use systemd to manage the service if it's present
-_use_systemctl=0
-
-# When systemd runs a shell script, bash sets PPID to 1 (init)
-if [ $PPID -ne 1 ] && \
-    # This variable lets the user disable systemd redirection
-    [ -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
-    # This tests whether systemd is currently managing the systemd
-    [ -d /run/systemd/system ] && \
-    # This variable is set when systemd >=232 runs a service
-    # We need this test in case systemd does not run the slapd-cli script
-    # directly (PPID>1) but runs it through /etc/init.d/slapd
-    [ -z "$INVOCATION_ID" ]  ;
-then
-	SYSTEMD_SERVICE_NAME=slapd-ltb
-	SYSTEMD_LLOAD_SERVICE_NAME=lload-ltb
-	_use_systemctl=1
-fi
-
-if [ "$SLAPD_USER" = "" ] ; then
-	PS_COMMAND_PID="ps -o pid -e"
-	PS_COMMAND_CMD="ps -o cmd -e"
-else
-	PS_COMMAND_PID="ps -o pid -u $SLAPD_USER"
-	PS_COMMAND_CMD="ps -o cmd -u $SLAPD_USER"
-fi
-
-
-#====================================================================
-# Initiate 'su' command
-#====================================================================
-if [ "$SLAPD_USER" -a $MYUID -eq 0 ]
-then
-	SU="su -s /bin/bash - $SLAPD_USER -c "
-fi
-
-#====================================================================
-# Initial checks
-#====================================================================
-
-# Make sure the pidfile directory exists with correct permissions
-piddir=`dirname "$SLAPD_PID_FILE"`
-if [ ! -d "$piddir" ]; then
-	mkdir -p "$piddir"
-	[ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" "$piddir"
-	[ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$piddir"
-fi
-
-# Rights to execute binaries
-for i in "$SLAPD_BIN" "$SLAPCAT_BIN" "$SLAPINDEX_BIN" "$SLAPTEST_BIN" "$LDAPSEARCH_BIN"
-do
-	if [ ! -x $i ]
-	then
-		message "alert" "[ALERT] Can't execute $i"
-		exit 1
-	fi
-done
-
-# Rights to read configuration
-if [ "$SLAPD_CONF" -a ! -r "$SLAPD_CONF" ]
-then
-	message "alert" "[ALERT] Can't read $SLAPD_CONF"
-	exit 1
-fi
-
-# Is there a configuration directory ?
-if [ "$SLAPD_CONF_DIR" -a ! -w "$SLAPD_CONF_DIR" ]
-then
-	message "alert" "[ALERT] Can't write to configuration directory $SLAPD_CONF_DIR"
-	exit 1
-fi
-
-# Are you root (for port < 1024)?
-if [ $PORT -lt 1024 -a $MYUID -ne 0 ]
-then
-	message "alert" "[ALERT] Only root can launch OpenLDAP on port $PORT"
-	exit 1
-fi
-
-# Create LDAPI socket
-if [ "$LDAPI_SOCKETDIR" -a ! -r "$LDAPI_SOCKETDIR" ]
-then
-    message "info" "[INFO] Create LDAPI socket dir $LDAPI_SOCKETDIR"
-    mkdir -p "$LDAPI_SOCKETDIR"
-    [ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" "$LDAPI_SOCKETDIR"
-    [ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$LDAPI_SOCKETDIR"
-fi
-
-#====================================================================
-# Functions
-#====================================================================
-
 display_usage() {
 	bold=$(tput bold)
 	normal=$(tput sgr0)
@@ -346,6 +243,141 @@ display_usage() {
 	printf "\n"
 
 }
+
+dryun=
+
+#====================================================================
+# Parameters switch
+#====================================================================
+while [[ $# > 0 ]]
+do
+    case $1 in
+        cli_conf_file)
+            shift
+            CLI_CONF_FILE=$1
+            ;;
+        help|usage)
+	    display_usage
+	    exit 1
+	    ;;
+        dryrun)
+            dryrun=dryrun
+            ;;
+        *)
+            # will be parsed as action
+            break
+            ;;
+    esac
+    shift
+done
+
+#====================================================================
+# Load specific parameters
+#====================================================================
+if [ -f ${CLI_CONF_FILE} ]
+then
+    . ${CLI_CONF_FILE}
+    message "info" "[INFO] Using ${CLI_CONF_FILE} for configuration"
+else
+    message "info" "[INFO] Using built-in configuration - this may cause some problems"
+fi
+
+if [[ -z $dryrun ]]
+then
+
+    # Use systemd to manage the service if it's present
+    _use_systemctl=0
+
+    # When systemd runs a shell script, bash sets PPID to 1 (init)
+    if [ $PPID -ne 1 ] && \
+           # This variable lets the user disable systemd redirection
+           [ -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
+               # This tests whether systemd is currently managing the systemd
+           [ -d /run/systemd/system ] && \
+               # This variable is set when systemd >=232 runs a service
+           # We need this test in case systemd does not run the slapd-cli script
+           # directly (PPID>1) but runs it through /etc/init.d/slapd
+           [ -z "$INVOCATION_ID" ]  ;
+    then
+	SYSTEMD_SERVICE_NAME=slapd-ltb
+	SYSTEMD_LLOAD_SERVICE_NAME=lload-ltb
+	_use_systemctl=1
+    fi
+
+    if [ "$SLAPD_USER" = "" ] ; then
+	PS_COMMAND_PID="ps -o pid -e"
+	PS_COMMAND_CMD="ps -o cmd -e"
+    else
+	PS_COMMAND_PID="ps -o pid -u $SLAPD_USER"
+	PS_COMMAND_CMD="ps -o cmd -u $SLAPD_USER"
+    fi
+
+
+    #====================================================================
+    # Initiate 'su' command
+    #====================================================================
+    if [ "$SLAPD_USER" -a $MYUID -eq 0 ]
+    then
+	SU="su -s /bin/bash - $SLAPD_USER -c "
+    fi
+
+    #====================================================================
+    # Initial checks
+    #====================================================================
+
+    # Make sure the pidfile directory exists with correct permissions
+    piddir=`dirname "$SLAPD_PID_FILE"`
+    if [ ! -d "$piddir" ]; then
+	mkdir -p "$piddir"
+	[ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" "$piddir"
+	[ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$piddir"
+    fi
+
+    # Rights to execute binaries
+    for i in "$SLAPD_BIN" "$SLAPCAT_BIN" "$SLAPINDEX_BIN" "$SLAPTEST_BIN" "$LDAPSEARCH_BIN"
+    do
+	if [ ! -x $i ]
+	then
+	    message "alert" "[ALERT] Can't execute $i"
+	    exit 1
+	fi
+    done
+
+    # Rights to read configuration
+    if [ "$SLAPD_CONF" -a ! -r "$SLAPD_CONF" ]
+    then
+	message "alert" "[ALERT] Can't read $SLAPD_CONF"
+	exit 1
+    fi
+
+    # Is there a configuration directory ?
+    if [ "$SLAPD_CONF_DIR" -a ! -w "$SLAPD_CONF_DIR" ]
+    then
+	message "alert" "[ALERT] Can't write to configuration directory $SLAPD_CONF_DIR"
+	exit 1
+    fi
+
+    # Are you root (for port < 1024)?
+    if [ $PORT -lt 1024 -a $MYUID -ne 0 ]
+    then
+	message "alert" "[ALERT] Only root can launch OpenLDAP on port $PORT"
+	exit 1
+    fi
+
+    # Create LDAPI socket
+    if [ "$LDAPI_SOCKETDIR" -a ! -r "$LDAPI_SOCKETDIR" ]
+    then
+        message "info" "[INFO] Create LDAPI socket dir $LDAPI_SOCKETDIR"
+        mkdir -p "$LDAPI_SOCKETDIR"
+        [ -z "$SLAPD_USER" ] || chown -R "$SLAPD_USER" "$LDAPI_SOCKETDIR"
+        [ -z "$SLAPD_GROUP" ] || chgrp -R "$SLAPD_GROUP" "$LDAPI_SOCKETDIR"
+    fi
+fi
+
+#====================================================================
+# Functions
+#====================================================================
+
 
 
 start_slapd() {
@@ -1703,33 +1735,11 @@ build_config_template() {
 
 }
 
+generate_data_admin_template() {
 
-import_data_template() {
-	message "info" "[INFO] Import test data..."
-
-	if [ -z ${DATA_TEMPLATE_FILE+x} ] || [ "${DATA_TEMPLATE_FILE}" = "" ]; then
-		message "alert" "[ALERT] No DATA_TEMPLATE_FILE variable defined"
-	fi
-
-
-
-	# Prepare template for replacement
-	DATA_TEMPLATE_PATH="${CLI_CONF_FILE%/*}/${DATA_TEMPLATE_FILE}"
-	if [ -f ${DATA_TEMPLATE_PATH} ]
-	then
-		message "info" "[INFO] Using ${DATA_TEMPLATE_PATH} as template"
-	else
-		message "error" "[ERROR] No data template found at ${DATA_TEMPLATE_PATH}"
-		exit 1
-	fi
-
-	DATA_FILE_PATH="${DATA_TEMPLATE_PATH%.ldif}-filled.ldif"
-	cp -f ${DATA_TEMPLATE_PATH} ${DATA_FILE_PATH}
-	chown $SLAPD_USER:$SLAPD_GROUP ${DATA_FILE_PATH}
-	chmod 640 ${DATA_FILE_PATH}
-
-
-	# Add new admins
+    local DATA_FILE_PATH="$1"
+    
+    	# Add new admins
 	DATA_ADMINS=$( set | grep -E '^DATA_ADMIN_' | sed -e 's/^DATA_ADMIN_\([^_]\+\)_.*/\1/' | sort -u )
 	for DATA_ADMIN in ${DATA_ADMINS}; do
 		eval DATA_ADMIN_DN="\$DATA_ADMIN_${DATA_ADMIN}_DN"
@@ -1762,14 +1772,24 @@ memberOf: cn=admin,ou=groups,DATA_SUFFIX" >> ${DATA_FILE_PATH}
 
 			MEMBER="member: ${DATA_ADMIN_DN}
 ${MEMBER}"
+                else
+                    collect_missing=''
+                    for suffix in _DN _PW _UID _SN _GN _MAIL
+                    do
+                        eval data="\$DATA_ADMIN_${DATA_ADMIN}$suffix"
+                        [[ -z $data ]] && collect_missing="DATA_ADMIN_${DATA_ADMIN}$suffix "$collect_missing
+                    done
+                    if [[ -n $collect_missing ]]
+                    then
+                        message 'warning' "[WARNING] for ${DATA_ADMIN} some values are missing ( $collect_missing) preventing admin to be created"
+                    fi
 		fi
 
 	done
 
-
 	# create new organizations and add people and groups branches inside
 	if [ ! -z ${DATA_ORGANIZATIONS+x} ] ; then
-		ORGS=${DATA_ORGANIZATIONS}, # adds final separator
+	        ORGS=${DATA_ORGANIZATIONS}, # adds final separator            
 		while [ ${ORGS} ]; do
 			o="${ORGS%%,*}" # get current organization
 			message "info" "[INFO] Adding organization ${o}"
@@ -1787,25 +1807,28 @@ ou: people
 dn: ou=groups,ou=${o},${DATA_SUFFIX}
 objectClass: organizationalUnit
 objectClass: top
-ou: groups
-
+ou: groups" >> ${DATA_FILE_PATH}
+                        if [[ -n $MEMBER ]]
+                        then
+                            printf "%s" "
 dn: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX}
 objectClass: groupOfNames
 objectClass: top
 cn: admin
 $MEMBER" >> ${DATA_FILE_PATH}
-
-			# Add corresponding memberOf
-			for DATA_ADMIN in ${DATA_ADMINS}; do
+			    # Add corresponding memberOf
+			    for DATA_ADMIN in ${DATA_ADMINS}; do
 				eval DATA_ADMIN_DN="\$DATA_ADMIN_${DATA_ADMIN}_DN"
 				sed -i -e "/^dn: ${DATA_ADMIN_DN}/amemberOf: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX}" ${DATA_FILE_PATH}
-			done
+			    done
+                        else
+                            message 'warning' "[WARNING] Can't create dn: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX} since there is no member to add in"
+                        fi
 
 			# remove current organization from list
 			ORGS=${ORGS#*,};
 		done;
 	fi
-
 
 	# Add admin group
 	MEMBER="member: DATA_SERVICEACCOUNT_DN
@@ -1847,10 +1870,45 @@ sn: ${DATA_USER_SN}
 uid: ${DATA_USER_UID}
 userPassword: ${DATA_USER_PW_HASH}" >> ${DATA_FILE_PATH}
 
-
+                else
+                    collect_missing=''
+                    for suffix in _DN _PW _UID _SN _GN _MAIL
+                    do
+                        eval data="\$DATA_USER_${DATA_USER}$suffix"
+                        [[ -z $data ]] && collect_missing="DATA_USER_${DATA_USER}$suffix "$collect_missing
+                    done
+                    if [[ -n $collect_missing ]]
+                    then
+                        message 'warning' "[WARNING] for ${DATA_USER} some values are missing ( $collect_missing) preventing user to be created"
+                    fi
 		fi
 
 	done
+}
+
+import_data_template() {
+	message "info" "[INFO] Import test data..."
+
+	if [ -z ${DATA_TEMPLATE_FILE+x} ] || [ "${DATA_TEMPLATE_FILE}" = "" ]; then
+		message "alert" "[ALERT] No DATA_TEMPLATE_FILE variable defined"
+	fi
+
+	# Prepare template for replacement
+	DATA_TEMPLATE_PATH="${CLI_CONF_FILE%/*}/${DATA_TEMPLATE_FILE}"
+	if [ -f ${DATA_TEMPLATE_PATH} ]
+	then
+		message "info" "[INFO] Using ${DATA_TEMPLATE_PATH} as template"
+	else
+		message "error" "[ERROR] No data template found at ${DATA_TEMPLATE_PATH}"
+		exit 1
+	fi
+
+	DATA_FILE_PATH="${DATA_TEMPLATE_PATH%.ldif}-filled.ldif"
+	cp -f ${DATA_TEMPLATE_PATH} ${DATA_FILE_PATH}
+	chown $SLAPD_USER:$SLAPD_GROUP ${DATA_FILE_PATH}
+	chmod 640 ${DATA_FILE_PATH}
+
+        generate_data_admin_template "${DATA_FILE_PATH}"
 
 	# Adapt LDAP suffix
 	message "info" "[INFO] Using suffix ${DATA_SUFFIX}"
@@ -2030,6 +2088,10 @@ case $1 in
 	lloadstatus)
 	display_lload_status
 	;;
+        # for testing purposes
+        generate_data_admin_template)
+            generate_data_admin_template "${CLI_CONF_FILE%/*}/test-filled.ldif"
+            ;;
 	*)
 	display_usage
 	exit 1

--- a/tests/default/expected.out
+++ b/tests/default/expected.out
@@ -1,0 +1,7 @@
+slapd-cli: [INFO] Using /home/philha/worteks/dev/ltb/openldap-initscript/tests/default/slapd-cli.conf for configuration
+slapd-cli: [INFO] Adding admin DJACKSON: uid=daniel.jackson, gn=Daniel, sn=Jackson, mail=daniel.jackson@my-example.com, pass=hashed_password
+slapd-cli: [INFO] Adding organization SG1
+slapd-cli: [INFO] Adding organization SG2
+slapd-cli: [INFO] Adding user JONEILL: uid=jack.oneill, gn=Jack, sn=O Neill, mail=jack.oneill@my-example.com, pass=hashed_password
+slapd-cli: [INFO] Adding user SCARTER: uid=samantha.carter, gn=Samantha, sn=Carter, mail=samantha.carter@my-example.com, pass=hashed_password
+slapd-cli: [INFO] Adding user TEALC: uid=tealc, gn=TealC, sn=Jaffa, mail=tealc@my-example.com, pass=hashed_password

--- a/tests/default/runtest.sh
+++ b/tests/default/runtest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+testname=$(<testname.txt)
+rm test-filled.ldif
+../../slapd-cli cli_conf_file $(pwd)/slapd-cli.conf dryrun generate_data_admin_template >myout.txt
+echo -n "test $testname " <&2
+if diff expected.out myout.txt && diff test-filled.ldif test-filled.ldif.expected
+then
+    echo '[PASSED]' >&2
+else
+    echo '[FAILED]' >&2
+fi

--- a/tests/default/sbin/slappasswd
+++ b/tests/default/sbin/slappasswd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "hashed_password"

--- a/tests/default/slapd-cli.conf
+++ b/tests/default/slapd-cli.conf
@@ -1,0 +1,115 @@
+#====================================================================
+# Configuration example of OpenLDAP's init script
+#====================================================================
+
+dummyvar=var
+
+# Networking parameters
+IP="*"
+PORT="389"
+SSLIP="*"
+SSLPORT="636"
+LDAPI_SOCKETDIR="${dummyvar}/run/slapd"
+LDAPI_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Fldapi"
+SLAPD_SERVICES="ldap://$IP:$PORT ldaps://$SSLIP:$SSLPORT ldapi://$LDAPI_SOCKETURL"
+
+# OpenLDAP directories and files
+SLAPD_PATH="."
+DATA_PATH="auto"
+SLAPD_PID_FILE="$SLAPD_PATH/var/run/slapd.pid"
+SLAPD_CONF="$SLAPD_PATH/etc/openldap/slapd.conf"
+SLAPD_CONF_DIR=""
+SLAPD_BIN="$SLAPD_PATH/libexec/slapd"
+SLAPD_PARAMS=""
+SLAPD_MODULEDIR="$SLAPD_PATH/libexec/openldap"
+SLAPADD_BIN="$SLAPD_PATH/sbin/slapadd"
+SLAPADD_PARAMS="-q"
+SLAPCAT_BIN="$SLAPD_PATH/sbin/slapcat"
+SLAPCAT_PARAMS="-o ldif-wrap=no"
+SLAPINDEX_BIN="$SLAPD_PATH/sbin/slapindex"
+SLAPTEST_BIN="$SLAPD_PATH/sbin/slaptest"
+LDAPSEARCH_BIN="${SLAPD_PATH}/bin/ldapsearch"
+
+# Other options for slapd launch
+SLAPD_USER=""
+SLAPD_GROUP=""
+SLAPD_SYSLOG_LOCAL_USER="local4"
+TIMEOUT="30" # Max time to stop process
+FD_LIMIT="1024" # Max file descriptor
+DEBUG_LEVEL="256" # Debug loglevel
+
+SLAPD_VERSION="2.5" # OpenLDAP version: major.minor (don't include .patch)
+
+# Backup
+BACKUP_AT_SHUTDOWN="0"
+BACKUP_PATH="$SLAPD_PATH/var/save"
+BACKUP_SUFFIX="`date +%Y%m%d%H%M%S`.ldif"
+BACKUP_COMPRESS_EXT="" # gz, bz2, ...
+BACKUP_COMPRESS_BIN="" # /bin/gzip, /bin/bzip2, ...
+BACKUP_UNCOMPRESS_BIN="" # /bin/gunzip, /bin/bunzip2, ...
+UMASK="umask"
+MASK="0027"
+
+# Data provisioning
+DATA_TEMPLATE_FILE="data-template-${SLAPD_VERSION}.ldif"
+DATA_SUFFIX="dc=my-domain,dc=com"
+DATA_ORGANIZATION="My Organization"
+DATA_SERVICEACCOUNT_DN="cn=my-account,ou=accounts,ou=infrastructure,${DATA_SUFFIX}"
+DATA_SERVICEACCOUNT_PW="secret"
+# Add automatically any number of admins and users
+# syntax for admins: DATA_ADMIN_<USER>_<ATTR>
+# syntax for users: DATA_USER_<USER>_<ATTR>
+# where <ATTR> is one of DN, PW, UID, SN, GN or MAIL
+# and <USER> is any unique value (not used for provisionning)
+DATA_ADMIN_DJACKSON_DN="uid=daniel.jackson,ou=people,${DATA_SUFFIX}"
+DATA_ADMIN_DJACKSON_PW="secret"
+DATA_ADMIN_DJACKSON_UID="daniel.jackson"
+DATA_ADMIN_DJACKSON_SN="Jackson"
+DATA_ADMIN_DJACKSON_GN="Daniel"
+DATA_ADMIN_DJACKSON_MAIL="daniel.jackson@my-example.com"
+DATA_USER_JONEILL_DN="uid=jack.oneill,ou=people,${DATA_SUFFIX}"
+DATA_USER_JONEILL_PW="secret"
+DATA_USER_JONEILL_UID="jack.oneill"
+DATA_USER_JONEILL_SN="O Neill"
+DATA_USER_JONEILL_GN="Jack"
+DATA_USER_JONEILL_MAIL="jack.oneill@my-example.com"
+DATA_USER_SCARTER_DN="uid=samantha.carter,ou=people,${DATA_SUFFIX}"
+DATA_USER_SCARTER_PW="secret"
+DATA_USER_SCARTER_UID="samantha.carter"
+DATA_USER_SCARTER_SN="Carter"
+DATA_USER_SCARTER_GN="Samantha"
+DATA_USER_SCARTER_MAIL="samantha.carter@my-example.com"
+DATA_USER_TEALC_DN="uid=tealc,ou=people,${DATA_SUFFIX}"
+DATA_USER_TEALC_PW="secret"
+DATA_USER_TEALC_UID="tealc"
+DATA_USER_TEALC_SN="Jaffa"
+DATA_USER_TEALC_GN="TealC"
+DATA_USER_TEALC_MAIL="tealc@my-example.com"
+DATA_ORGANIZATIONS="SG1,SG2"
+
+# Config provisioning
+CONFIG_FLAT_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.conf"
+CONFIG_LDIF_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.ldif"
+CONFIG_SUFFIX="dc=my-domain,dc=com"
+CONFIG_FQDN="ldap.my-domain.com"
+CONFIG_LOGLEVEL="256"
+CONFIG_LOGFILE="${dummyvar}/log/slapd-ltb/slapd.log"
+CONFIG_MANAGERROOTDN="cn=Manager,dc=my-domain,dc=com"
+CONFIG_MANAGERROOTPW="secret"
+CONFIG_CONFIGROOTDN="cn=config"
+CONFIG_CONFIGROOTPW="secret"
+CONFIG_MONITORROOTDN="cn=monitor"
+CONFIG_MONITORROOTPW="secret"
+CONFIG_DATADIR="${SLAPD_PATH}/var/openldap-data"
+
+# lload
+LLOAD_IP="*"
+LLOAD_PORT="3389"
+LLOAD_SSLIP="*"
+LLOAD_SSLPORT="6636"
+LLOAD_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Flload"
+LLOAD_SERVICES="ldap://${LLOAD_IP}:${LLOAD_PORT} ldaps://${LLOAD_SSLIP}:${LLOAD_SSLPORT} ldapi://$LLOAD_SOCKETURL"
+LLOAD_PID_FILE="$SLAPD_PATH/var/run/lload.pid"
+LLOAD_CONF="$SLAPD_PATH/etc/openldap/lload.conf"
+LLOAD_CONF_DIR=""
+

--- a/tests/default/test-filled.ldif.expected
+++ b/tests/default/test-filled.ldif.expected
@@ -1,0 +1,103 @@
+
+
+dn: uid=daniel.jackson,ou=people,dc=my-domain,dc=com
+memberOf: cn=admin,ou=groups,ou=SG2,dc=my-domain,dc=com
+memberOf: cn=admin,ou=groups,ou=SG1,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Daniel Jackson
+givenName: Daniel
+mail: daniel.jackson@my-example.com
+sn: Jackson
+uid: daniel.jackson
+userPassword: hashed_password
+pwdPolicySubentry: cn=admin-policy,ou=ppolicies,DATA_SUFFIX
+memberOf: cn=admin,ou=groups,DATA_SUFFIX
+
+dn: ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: SG1
+
+dn: ou=people,ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: people
+
+dn: ou=groups,ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+dn: cn=admin,ou=groups,ou=SG1,dc=my-domain,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: admin
+member: uid=daniel.jackson,ou=people,dc=my-domain,dc=com
+
+
+dn: ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: SG2
+
+dn: ou=people,ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: people
+
+dn: ou=groups,ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+dn: cn=admin,ou=groups,ou=SG2,dc=my-domain,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: admin
+member: uid=daniel.jackson,ou=people,dc=my-domain,dc=com
+
+
+dn: cn=admin,ou=groups,DATA_SUFFIX
+objectClass: groupOfNames
+objectClass: top
+cn: admin
+member: DATA_SERVICEACCOUNT_DN
+member: uid=daniel.jackson,ou=people,dc=my-domain,dc=com
+
+
+dn: uid=jack.oneill,ou=people,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Jack O Neill
+givenName: Jack
+mail: jack.oneill@my-example.com
+sn: O Neill
+uid: jack.oneill
+userPassword: hashed_password
+
+dn: uid=samantha.carter,ou=people,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Samantha Carter
+givenName: Samantha
+mail: samantha.carter@my-example.com
+sn: Carter
+uid: samantha.carter
+userPassword: hashed_password
+
+dn: uid=tealc,ou=people,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: TealC Jaffa
+givenName: TealC
+mail: tealc@my-example.com
+sn: Jaffa
+uid: tealc
+userPassword: hashed_password

--- a/tests/default/testname.txt
+++ b/tests/default/testname.txt
@@ -1,0 +1,1 @@
+default

--- a/tests/missing_admin/expected.out
+++ b/tests/missing_admin/expected.out
@@ -1,0 +1,9 @@
+slapd-cli: [INFO] Using /home/philha/worteks/dev/ltb/openldap-initscript/tests/missing_admin/slapd-cli.conf for configuration
+slapd-cli: [WARNING] for DJACKSON some values are missing ( DATA_ADMIN_DJACKSON_GN ) preventing admin to be created
+slapd-cli: [INFO] Adding organization SG1
+slapd-cli: [WARNING] Can't create dn: cn=admin,ou=groups,ou=SG1,dc=my-domain,dc=com since there is no member to add in
+slapd-cli: [INFO] Adding organization SG2
+slapd-cli: [WARNING] Can't create dn: cn=admin,ou=groups,ou=SG2,dc=my-domain,dc=com since there is no member to add in
+slapd-cli: [WARNING] for JONEILL some values are missing ( DATA_USER_JONEILL_MAIL ) preventing user to be created
+slapd-cli: [INFO] Adding user SCARTER: uid=samantha.carter, gn=Samantha, sn=Carter, mail=samantha.carter@my-example.com, pass=hashed_password
+slapd-cli: [INFO] Adding user TEALC: uid=tealc, gn=TealC, sn=Jaffa, mail=tealc@my-example.com, pass=hashed_password

--- a/tests/missing_admin/runtest.sh
+++ b/tests/missing_admin/runtest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+testname=$(<testname.txt)
+rm test-filled.ldif
+../../slapd-cli cli_conf_file $(pwd)/slapd-cli.conf dryrun generate_data_admin_template >myout.txt
+echo -n "test $testname " <&2
+if diff expected.out myout.txt && diff test-filled.ldif test-filled.ldif.expected
+then
+    echo '[PASSED]' >&2
+else
+    echo '[FAILED]' >&2
+fi

--- a/tests/missing_admin/sbin/slappasswd
+++ b/tests/missing_admin/sbin/slappasswd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "hashed_password"

--- a/tests/missing_admin/slapd-cli.conf
+++ b/tests/missing_admin/slapd-cli.conf
@@ -1,0 +1,115 @@
+#====================================================================
+# Configuration example of OpenLDAP's init script
+#====================================================================
+
+dummyvar=var
+
+# Networking parameters
+IP="*"
+PORT="389"
+SSLIP="*"
+SSLPORT="636"
+LDAPI_SOCKETDIR="${dummyvar}/run/slapd"
+LDAPI_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Fldapi"
+SLAPD_SERVICES="ldap://$IP:$PORT ldaps://$SSLIP:$SSLPORT ldapi://$LDAPI_SOCKETURL"
+
+# OpenLDAP directories and files
+SLAPD_PATH="."
+DATA_PATH="auto"
+SLAPD_PID_FILE="$SLAPD_PATH/var/run/slapd.pid"
+SLAPD_CONF="$SLAPD_PATH/etc/openldap/slapd.conf"
+SLAPD_CONF_DIR=""
+SLAPD_BIN="$SLAPD_PATH/libexec/slapd"
+SLAPD_PARAMS=""
+SLAPD_MODULEDIR="$SLAPD_PATH/libexec/openldap"
+SLAPADD_BIN="$SLAPD_PATH/sbin/slapadd"
+SLAPADD_PARAMS="-q"
+SLAPCAT_BIN="$SLAPD_PATH/sbin/slapcat"
+SLAPCAT_PARAMS="-o ldif-wrap=no"
+SLAPINDEX_BIN="$SLAPD_PATH/sbin/slapindex"
+SLAPTEST_BIN="$SLAPD_PATH/sbin/slaptest"
+LDAPSEARCH_BIN="${SLAPD_PATH}/bin/ldapsearch"
+
+# Other options for slapd launch
+SLAPD_USER=""
+SLAPD_GROUP=""
+SLAPD_SYSLOG_LOCAL_USER="local4"
+TIMEOUT="30" # Max time to stop process
+FD_LIMIT="1024" # Max file descriptor
+DEBUG_LEVEL="256" # Debug loglevel
+
+SLAPD_VERSION="2.5" # OpenLDAP version: major.minor (don't include .patch)
+
+# Backup
+BACKUP_AT_SHUTDOWN="0"
+BACKUP_PATH="$SLAPD_PATH/var/save"
+BACKUP_SUFFIX="`date +%Y%m%d%H%M%S`.ldif"
+BACKUP_COMPRESS_EXT="" # gz, bz2, ...
+BACKUP_COMPRESS_BIN="" # /bin/gzip, /bin/bzip2, ...
+BACKUP_UNCOMPRESS_BIN="" # /bin/gunzip, /bin/bunzip2, ...
+UMASK="umask"
+MASK="0027"
+
+# Data provisioning
+DATA_TEMPLATE_FILE="data-template-${SLAPD_VERSION}.ldif"
+DATA_SUFFIX="dc=my-domain,dc=com"
+DATA_ORGANIZATION="My Organization"
+DATA_SERVICEACCOUNT_DN="cn=my-account,ou=accounts,ou=infrastructure,${DATA_SUFFIX}"
+DATA_SERVICEACCOUNT_PW="secret"
+# Add automatically any number of admins and users
+# syntax for admins: DATA_ADMIN_<USER>_<ATTR>
+# syntax for users: DATA_USER_<USER>_<ATTR>
+# where <ATTR> is one of DN, PW, UID, SN, GN or MAIL
+# and <USER> is any unique value (not used for provisionning)
+DATA_ADMIN_DJACKSON_DN="uid=daniel.jackson,ou=people,${DATA_SUFFIX}"
+DATA_ADMIN_DJACKSON_PW="secret"
+DATA_ADMIN_DJACKSON_UID="daniel.jackson"
+DATA_ADMIN_DJACKSON_SN="Jackson"
+#DATA_ADMIN_DJACKSON_GN="Daniel"
+DATA_ADMIN_DJACKSON_MAIL="daniel.jackson@my-example.com"
+DATA_USER_JONEILL_DN="uid=jack.oneill,ou=people,${DATA_SUFFIX}"
+DATA_USER_JONEILL_PW="secret"
+DATA_USER_JONEILL_UID="jack.oneill"
+DATA_USER_JONEILL_SN="O Neill"
+DATA_USER_JONEILL_GN="Jack"
+#DATA_USER_JONEILL_MAIL="jack.oneill@my-example.com"
+DATA_USER_SCARTER_DN="uid=samantha.carter,ou=people,${DATA_SUFFIX}"
+DATA_USER_SCARTER_PW="secret"
+DATA_USER_SCARTER_UID="samantha.carter"
+DATA_USER_SCARTER_SN="Carter"
+DATA_USER_SCARTER_GN="Samantha"
+DATA_USER_SCARTER_MAIL="samantha.carter@my-example.com"
+DATA_USER_TEALC_DN="uid=tealc,ou=people,${DATA_SUFFIX}"
+DATA_USER_TEALC_PW="secret"
+DATA_USER_TEALC_UID="tealc"
+DATA_USER_TEALC_SN="Jaffa"
+DATA_USER_TEALC_GN="TealC"
+DATA_USER_TEALC_MAIL="tealc@my-example.com"
+DATA_ORGANIZATIONS="SG1,SG2"
+
+# Config provisioning
+CONFIG_FLAT_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.conf"
+CONFIG_LDIF_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.ldif"
+CONFIG_SUFFIX="dc=my-domain,dc=com"
+CONFIG_FQDN="ldap.my-domain.com"
+CONFIG_LOGLEVEL="256"
+CONFIG_LOGFILE="${dummyvar}/log/slapd-ltb/slapd.log"
+CONFIG_MANAGERROOTDN="cn=Manager,dc=my-domain,dc=com"
+CONFIG_MANAGERROOTPW="secret"
+CONFIG_CONFIGROOTDN="cn=config"
+CONFIG_CONFIGROOTPW="secret"
+CONFIG_MONITORROOTDN="cn=monitor"
+CONFIG_MONITORROOTPW="secret"
+CONFIG_DATADIR="${SLAPD_PATH}/var/openldap-data"
+
+# lload
+LLOAD_IP="*"
+LLOAD_PORT="3389"
+LLOAD_SSLIP="*"
+LLOAD_SSLPORT="6636"
+LLOAD_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Flload"
+LLOAD_SERVICES="ldap://${LLOAD_IP}:${LLOAD_PORT} ldaps://${LLOAD_SSLIP}:${LLOAD_SSLPORT} ldapi://$LLOAD_SOCKETURL"
+LLOAD_PID_FILE="$SLAPD_PATH/var/run/lload.pid"
+LLOAD_CONF="$SLAPD_PATH/etc/openldap/lload.conf"
+LLOAD_CONF_DIR=""
+

--- a/tests/missing_admin/test-filled.ldif.expected
+++ b/tests/missing_admin/test-filled.ldif.expected
@@ -1,0 +1,62 @@
+
+
+dn: ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: SG1
+
+dn: ou=people,ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: people
+
+dn: ou=groups,ou=SG1,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+
+dn: ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: SG2
+
+dn: ou=people,ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: people
+
+dn: ou=groups,ou=SG2,dc=my-domain,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+
+dn: cn=admin,ou=groups,DATA_SUFFIX
+objectClass: groupOfNames
+objectClass: top
+cn: admin
+member: DATA_SERVICEACCOUNT_DN
+
+
+dn: uid=samantha.carter,ou=people,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Samantha Carter
+givenName: Samantha
+mail: samantha.carter@my-example.com
+sn: Carter
+uid: samantha.carter
+userPassword: hashed_password
+
+dn: uid=tealc,ou=people,dc=my-domain,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: TealC Jaffa
+givenName: TealC
+mail: tealc@my-example.com
+sn: Jaffa
+uid: tealc
+userPassword: hashed_password

--- a/tests/missing_admin/testname.txt
+++ b/tests/missing_admin/testname.txt
@@ -1,0 +1,1 @@
+missing_admin

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+for ford in $(ls)
+do
+    if [[ -d $ford ]]
+    then
+        pushd $ford >/dev/null
+        ./runtest.sh
+        popd >/dev/null
+    fi
+done


### PR DESCRIPTION
- WARN when data are missing and user, admin, and membership not generated
- don't generate missing member : don't add admin group at all.
- tests contains check for template generation wihtout a real ldap installed
- adapted slapd-cli to support dryrun limited functionality for given tests