### PR TITLE
Checks for DATA_ADMIN_X and DATA_USER_Y missing X or Y issue #50

### DIFF
--- a/slapd-cli
+++ b/slapd-cli
@@ -1762,6 +1762,14 @@ memberOf: cn=admin,ou=groups,DATA_SUFFIX" >> ${DATA_FILE_PATH}
 
 			MEMBER="member: ${DATA_ADMIN_DN}
 ${MEMBER}"
+		else
+			collect_missing=''
+			for suffix in DN PW UID SN GN MAIL
+			do
+				eval data="\$DATA_ADMIN_${DATA_ADMIN}_$suffix"
+				[[ -z $data ]] && collect_missing="DATA_ADMIN_${DATA_ADMIN}_$suffix "$collect_missing
+			done
+			[[ -n $collect_missing ]] && message 'warning' "[WARNING] for ${DATA_ADMIN} some values are missing ( $collect_missing) preventing admin to be created"
 		fi
 
 	done
@@ -1787,19 +1795,25 @@ ou: people
 dn: ou=groups,ou=${o},${DATA_SUFFIX}
 objectClass: organizationalUnit
 objectClass: top
-ou: groups
+ou: groups" >> ${DATA_FILE_PATH}
 
+			if [[ -n $MEMBER ]]
+			then
+				printf "%s" "
 dn: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX}
 objectClass: groupOfNames
 objectClass: top
 cn: admin
 $MEMBER" >> ${DATA_FILE_PATH}
 
-			# Add corresponding memberOf
-			for DATA_ADMIN in ${DATA_ADMINS}; do
-				eval DATA_ADMIN_DN="\$DATA_ADMIN_${DATA_ADMIN}_DN"
-				sed -i -e "/^dn: ${DATA_ADMIN_DN}/amemberOf: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX}" ${DATA_FILE_PATH}
-			done
+				# Add corresponding memberOf
+				for DATA_ADMIN in ${DATA_ADMINS}; do
+					eval DATA_ADMIN_DN="\$DATA_ADMIN_${DATA_ADMIN}_DN"
+					sed -i -e "/^dn: ${DATA_ADMIN_DN}/amemberOf: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX}" ${DATA_FILE_PATH}
+				done
+			else
+				message 'warning' "[WARNING] Can't create dn: cn=admin,ou=groups,ou=${o},${DATA_SUFFIX} since there is no member to add in"
+			fi
 
 			# remove current organization from list
 			ORGS=${ORGS#*,};
@@ -1847,6 +1861,14 @@ sn: ${DATA_USER_SN}
 uid: ${DATA_USER_UID}
 userPassword: ${DATA_USER_PW_HASH}" >> ${DATA_FILE_PATH}
 
+		else
+			collect_missing=''
+			for suffix in DN PW UID SN GN MAIL
+			do
+				eval data="\$DATA_USER_${DATA_USER}_$suffix"
+				[[ -z $data ]] && collect_missing="DATA_USER_${DATA_USER}_$suffix "$collect_missing
+			done
+			[[ -n $collect_missing ]] && message 'warning' "[WARNING] for ${DATA_USER} some values are missing ( $collect_missing) preventing user to be created"
 
 		fi
 


### PR DESCRIPTION
- WARN when data are missing and user, admin, and membership not generated
- Don't generate missing member : don't add admin group at all.