### PR TITLE
Bug fix in check_sync (base64 decode olcsyncrepl and anonymous bind)

### DIFF
--- a/slapd-cli
+++ b/slapd-cli
@@ -209,10 +209,17 @@ syncrepl_get_value() {
 	echo "$syncrepl" | grep -e $parameter'="' > /dev/null
 	noquotes=$?
 
-	if [ $noquotes -gt 0 ]
+	# Check if parameter value is present in the syncrepl value
+	echo "$syncrepl" | grep -e $parameter > /dev/null
+	noparam=$?
+
+	if [ $noparam -gt 0 ]
 	then
+		RETVAL=""
+	elif [ $noquotes -gt 0 ]
+	then 
 		RETVAL=$( echo "$syncrepl" | sed -e 's/.*'$parameter'[ \t]*=[ \t]*\([^ \t]\+\).*$/\1/' | sed -e 's/["]//g' | sed -e "s/[']//g")
-	else
+	else 
 		RETVAL=$( echo "$syncrepl" | sed -e 's/.*'$parameter'[ \t]*=[ \t]*"\([^"\t]\+\)".*$/\1/' | sed -e 's/["]//g' | sed -e "s/[']//g");
 	fi
 }
@@ -1354,7 +1361,13 @@ check_sync() {
 			PBASEDN=$RETVAL
 			echo "Checking contextCSN for suffix ${SUFFIX} on remote host ${PHOST}"
 			# Get remote provider contextCSN (one contextCSN per line)
-			CONTEXTCSN=$( ${LDAPSEARCH_BIN} -x -H "${PHOST}" -D "${PBINDDN}" -w "${PBINDPW}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null )
+			# If bindDN is empty, try anonymous bind
+			if [ -z "$PBINDDN" ]; then
+				CONTEXTCSN=$(LDAPTLS_REQCERT=never ${LDAPSEARCH_BIN} -x -H "${PHOST}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null )
+			else
+				CONTEXTCSN=$(LDAPTLS_REQCERT=never ${LDAPSEARCH_BIN} -x -H "${PHOST}" -D "${PBINDDN}" -w "${PBINDPW}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null )
+	
+			fi
 
 			# Checking status of previous command
 			if [ $? -ne 0 ]; then
@@ -1365,7 +1378,12 @@ check_sync() {
 			CONTEXTCSN=$( echo "$CONTEXTCSN" | grep contextCSN | sed -e 's/^contextCSN: //i' )
 
 			# get local contextCSN
-			localContextCSN=$( ${LDAPSEARCH_BIN} -x -H "${LOCAL_URL}" -D "${PBINDDN}" -w "${PBINDPW}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null | grep 'contextCSN' | sed -e 's/^contextCSN: //' )
+			# If bindDN is empty, try anonymous bind
+			if [ -z "$PBINDDN" ]; then
+				localContextCSN=$(LDAPTLS_REQCERT=never ${LDAPSEARCH_BIN} -x -H "${LOCAL_URL}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null | grep 'contextCSN' | sed -e 's/^contextCSN: //' )
+			else
+				localContextCSN=$(LDAPTLS_REQCERT=never ${LDAPSEARCH_BIN} -x -H "${LOCAL_URL}" -D "${PBINDDN}" -w "${PBINDPW}" -b "${PBASEDN}" -o nettimeout=5 -s base ${LDAPSEARCH_PARAMS} contextCSN -LLL 2>/dev/null | grep 'contextCSN' | sed -e 's/^contextCSN: //' )
+			fi
 
 			# compare contextCSN values
 			# for each provider contextCSN

--- a/slapd-cli
+++ b/slapd-cli
@@ -1246,6 +1246,12 @@ get_provider_config() {
 			if printf "$LINE" | grep -q -P '^olcSuffix:[ \t]+' ; then
 				SUF="$( printf "$LINE" | sed -e 's/^olcSuffix:[ \t]\+//' -e 's/"//g' )"
 			fi
+			# test if the olcSyncrepl attribute is base64 encoded - decode it if yes before processing the line
+			if printf "$LINE" | grep -q -P '^olcSyncrepl::' ; then
+					LINEDECODED="olcSyncrepl: "
+					LINEDECODED+=$(echo "$LINE" | cut -d ' ' -f 2 | base64 -d -i)
+					LINE=$LINEDECODED
+			fi
 			if printf "$LINE" | grep -q -P '^olcSyncrepl:[ \t]+' ; then
 				# add detected provider to the list of detected providers for this suffix (\n separated)
 				PROVIDER[${SUF}]="${PROVIDER[$SUF]}\n$( printf "${LINE}" | sed -e 's/olcSyncrepl:[ \t]\+{*[0-9]*}*//' )"


### PR DESCRIPTION
Hello, 

I would like to merge the following changes aimed to:

- Decode the olcSyncrepl attribute if it is base64 encoded before processing. Currently it is not the case so the get_provider_config() fails in such case.
- Fix the syncrepl_get_value() : when the searched attribute is not in the olcSyncrepl definition, the "sed" operation returns the entire content of the syncrepl. I suggest to return an empty value in that case.
- In the check_sync(), if no bindDN is found by syncrepl_get_value, try an anonymous bind instead of just failing.